### PR TITLE
Fix broken html highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mint",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/syntaxes/mint.tmLanguage.json
+++ b/syntaxes/mint.tmLanguage.json
@@ -18,7 +18,7 @@
       "patterns": [
         {
           "name": "keyword.control.mint",
-          "match": "\\b(global|state|encode|decode|for|module|provider|suite|test|parallel|sequence|case|try|catch|next|with|component|property|fun|routes|get|connect|exposing|record|store|use|when|if|else|where)\\b"
+          "match": "\\b(global|state|encode|decode|for|module|provider|suite|test|parallel|sequence|case|try|catch|next|with|component|property|fun|style|routes|get|connect|exposing|record|store|use|when|if|else|where)\\b"
         },
         {
           "name": "entity.name.class.mint",
@@ -47,8 +47,8 @@
       ]
     },
     "html": {
-      "begin": "(?i)(?=:(\\\\s*)Html(\\\\s*){),",
-      "end": "(?<=>})|^\\\\s*}$,",
+      "begin": "(?i)(?=:(\\s*)Html(\\s*){)",
+      "end": "(?<=>})|^\\s*}$",
       "contentName": "embedded.html",
       "patterns": [
         {

--- a/syntaxes/mint.tmLanguage.yaml
+++ b/syntaxes/mint.tmLanguage.yaml
@@ -14,7 +14,7 @@ repository:
       [
         {
           name: keyword.control.mint,
-          match: \b(global|state|encode|decode|for|module|provider|suite|test|parallel|sequence|case|try|catch|next|with|component|property|fun|routes|get|connect|exposing|record|store|use|when|if|else|where)\b,
+          match: \b(global|state|encode|decode|for|module|provider|suite|test|parallel|sequence|case|try|catch|next|with|component|property|fun|style|routes|get|connect|exposing|record|store|use|when|if|else|where)\b,
         },
         {
           name: entity.name.class.mint,
@@ -31,8 +31,8 @@ repository:
     patterns: [{ name: constant.character.escape.mint, match: "\\\\." }]
 
   html:
-    begin: (?i)(?=:(\\s*)Html(\\s*){),
-    end: (?<=>})|^\\s*}$,
+    begin: "(?i)(?=:(\\s*)Html(\\s*){)"
+    end: "(?<=>})|^\\s*}$"
     contentName: embedded.html
     patterns:
       [


### PR DESCRIPTION
This does two things:

1. Adds `style` to the control keywords
2. Fixes an issue with backslashes being extra escaped due to the yaml transform