### PR TITLE
Hide Command Palette commands when not in a Mint project

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,8 @@
   },
   "activationEvents": [
     "onLanguage:mint",
-    "onCommand:mint.build",
-    "onCommand:mint.compile",
-    "onCommand:mint.docs",
-    "onCommand:mint.formatAll",
-    "onCommand:mint.init",
-    "onCommand:mint.install",
-    "onCommand:mint.loc",
-    "onCommand:mint.start",
-    "onCommand:mint.test",
-    "onCommand:mint.version"
+    "workspaceContains:**/*.mint",
+    "onCommand:mint.init"
   ],
   "main": "./out/src/extension",
   "devDependencies": {
@@ -71,44 +63,97 @@
     "commands": [
       {
         "command": "mint.build",
-        "title": "Mint: Build production bundle"
+        "title": "Build production bundle",
+        "category": "Mint"
       },
       {
         "command": "mint.compile",
-        "title": "Mint: Compile project into single JavaScript file"
+        "title": "Compile project into single JavaScript file",
+        "category": "Mint"
       },
       {
         "command": "mint.docs",
-        "title": "Mint: Start documentation server"
+        "title": "Start documentation server",
+        "category": "Mint"
       },
       {
         "command": "mint.formatAll",
-        "title": "Mint: Format all files"
+        "title": "Format all files",
+        "category": "Mint"
       },
       {
         "command": "mint.init",
-        "title": "Mint: Initialize new project"
+        "title": "Initialize new project",
+        "category": "Mint"
       },
       {
         "command": "mint.install",
-        "title": "Mint: Install dependencies"
+        "title": "Install dependencies",
+        "category": "Mint"
       },
       {
         "command": "mint.loc",
-        "title": "Mint: Count lines of code"
+        "title": "Count lines of code",
+        "category": "Mint"
       },
       {
         "command": "mint.start",
-        "title": "Mint: Start development server"
+        "title": "Start development server",
+        "category": "Mint"
       },
       {
         "command": "mint.test",
-        "title": "Mint: Run tests"
+        "title": "Run tests",
+        "category": "Mint"
       },
       {
         "command": "mint.version",
-        "title": "Mint: Show current version"
+        "title": "Show current version",
+        "category": "Mint"
       }
-    ]
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "mint.build",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.compile",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.docs",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.formatAll",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.init"
+        },
+        {
+          "command": "mint.install",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.loc",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.start",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.test",
+          "when": "mint:isActivated"
+        },
+        {
+          "command": "mint.version",
+          "when": "mint:isActivated"
+        }
+      ]
+    }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,20 +2,33 @@ import * as vscode from "vscode";
 import { MintFormattingProvider } from "./formatter";
 import * as cmd from "./commands";
 
-// Register formatting provider
-vscode.languages.registerDocumentFormattingEditProvider(
-  "mint",
-  new MintFormattingProvider()
-);
+export async function activate(
+  context: vscode.ExtensionContext,
+  isRestart: boolean = false
+): Promise<void> {
+  // Set context activated
+  vscode.commands.executeCommand("setContext", "mint:isActivated", true);
 
-// Register commands
-vscode.commands.registerCommand("mint.build", cmd.mintBuildCommand);
-vscode.commands.registerCommand("mint.compile", cmd.mintCompileCommand);
-vscode.commands.registerCommand("mint.docs", cmd.mintDocsCommand);
-vscode.commands.registerCommand("mint.formatAll", cmd.mintFormatAllCommand);
-vscode.commands.registerCommand("mint.init", cmd.mintInitCommand);
-vscode.commands.registerCommand("mint.install", cmd.mintInstallCommand);
-vscode.commands.registerCommand("mint.loc", cmd.mintCountLinesCommand);
-vscode.commands.registerCommand("mint.start", cmd.mintStartCommand);
-vscode.commands.registerCommand("mint.test", cmd.mintTestCommand);
-vscode.commands.registerCommand("mint.version", cmd.mintVersionCommand);
+  // Register formatting provider
+  vscode.languages.registerDocumentFormattingEditProvider(
+    "mint",
+    new MintFormattingProvider()
+  );
+
+  // Register commands
+  vscode.commands.registerCommand("mint.build", cmd.mintBuildCommand);
+  vscode.commands.registerCommand("mint.compile", cmd.mintCompileCommand);
+  vscode.commands.registerCommand("mint.docs", cmd.mintDocsCommand);
+  vscode.commands.registerCommand("mint.formatAll", cmd.mintFormatAllCommand);
+  vscode.commands.registerCommand("mint.init", cmd.mintInitCommand);
+  vscode.commands.registerCommand("mint.install", cmd.mintInstallCommand);
+  vscode.commands.registerCommand("mint.loc", cmd.mintCountLinesCommand);
+  vscode.commands.registerCommand("mint.start", cmd.mintStartCommand);
+  vscode.commands.registerCommand("mint.test", cmd.mintTestCommand);
+  vscode.commands.registerCommand("mint.version", cmd.mintVersionCommand);
+}
+
+export async function deactivate(isRestart: boolean = false): Promise<void> {
+  /// Set context deactivated
+  vscode.commands.executeCommand("setContext", "mint:isActivated", false);
+}


### PR DESCRIPTION
Mint commands were showing up all the time, so now all commands are hidden except `mint.init` until you are in a project that contains a Mint file.

We also now use command grouping.