### PR TITLE
feat(workflow): Add publishing to OpenVSX Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Deploy Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}


### PR DESCRIPTION
The purpose of this PR is to propose the addition of publishing extension to [Open VSX Registry](https://open-vsx.org).

I initially ran tests on the main branch of my fork and released a test version [here](https://open-vsx.org/extension/mint-lang/mint).